### PR TITLE
[프로그래머스 Lv1] 달리기 경주 구현

### DIFF
--- a/algorithm/src/main/kotlin/programmersLv1/달리기 경주.kt
+++ b/algorithm/src/main/kotlin/programmersLv1/달리기 경주.kt
@@ -1,0 +1,28 @@
+package programmersLv1
+
+fun main() {
+    val players = arrayOf("mumu", "soe", "poe", "kai", "mine")
+    val callings = arrayOf("kai", "kai", "mine", "mine")
+    val result = solution(players, callings)
+    print(result.contentToString())
+}
+
+private fun solution(players: Array<String>, callings: Array<String>): Array<String> {
+    val rankMap = mutableMapOf<String, Int>()
+    players.forEachIndexed { index, s ->
+        rankMap[s] = index
+    }
+
+    callings.forEachIndexed { _, s ->
+        val callRank = rankMap[s] ?: 0
+        val frontPlayer = players[callRank - 1]
+
+        players[callRank - 1] = s
+        players[callRank] = frontPlayer
+
+        rankMap[s] = callRank - 1
+        rankMap[frontPlayer] = callRank
+    }
+
+    return players
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #5

## 🔑 How to Solve

- players를 Map으로 순위와 이름을 저장
- callings의 순위를 받아와 이름이 불릴 때마다 앞에 있는 사람과 순위 변경

